### PR TITLE
Fix participationsPropTypes import

### DIFF
--- a/app/containers/ContestParticipantsPage/index.js
+++ b/app/containers/ContestParticipantsPage/index.js
@@ -10,7 +10,8 @@ import messages from './messages';
 import { getContestId } from '../ContestPage';
 
 import { loadable } from '../../utils/render';
-import ContestParticipations, { ContestParticipationsFragment, participationsPropTypes }
+import { participationsPropTypes } from '../../components/ContestParticipants/constants';
+import ContestParticipations, { ContestParticipationsFragment }
   from '../../components/ContestParticipants';
 import EmptyMessage from '../../components/EmptyMessage';
 


### PR DESCRIPTION
Fixes webpack warning:
```
WARNING in ./app/containers/ContestParticipantsPage/index.js
42:22 export 'participationsPropTypes' was not found in
'../../components/ContestParticipants'
```